### PR TITLE
Scale transformations per facet

### DIFF
--- a/tests/testthat/test-facet_grid_sc.R
+++ b/tests/testthat/test-facet_grid_sc.R
@@ -8,3 +8,26 @@ test_that("facet_grid_sc() accepts custom scales per facet", {
   expect_identical(grid$params$scales$y, sc_y)
 })
 
+test_that("facet_grid_sc() accepts transformations", {
+  sc_y <- list(setosa = ggplot2::scale_y_reverse(),
+               versicolor = ggplot2::scale_y_sqrt(),
+               virginica = ggplot2::scale_y_continuous())
+
+  ctrl <- ggplot2::ggplot(iris, ggplot2::aes(Sepal.Length, Sepal.Width,
+                                             colour = Species)) +
+    ggplot2::geom_point()
+  test <- ctrl + facet_grid_sc(Species ~ ., scales = list(x = "fixed", y = sc_y))
+  ctrl <- ctrl + ggplot2::facet_grid(Species ~ ., scales = "free_y")
+
+  ctrl <- ggplot2::layer_data(ctrl)
+  test <- ggplot2::layer_data(test)
+
+  expect_identical(ctrl[ctrl$PANEL == 1, "y"] * -1,
+                   test[test$PANEL == 1, "y"])
+
+  expect_identical(ctrl[ctrl$PANEL == 2, "y"] ^ 0.5,
+                   test[test$PANEL == 2, "y"])
+
+  expect_identical(ctrl[ctrl$PANEL == 3, "y"],
+                   test[test$PANEL == 3, "y"])
+})


### PR DESCRIPTION
Adressing #3, this addition would allow scale transformations to work along the columns and rows of the grid facets.

Changes are at three places.

1. In the `init_scales` ggproto method, scale cloning occurs with a custom out of bounds (`oob`) function that does literally nothing but to pass along all data. This function is needed because with the default `censor` behaviour, data is being assigned `NA`s before the scales are trained. These `NA`s occur because the data easily becomes out of bounds under most transformations.

2. The `finish_data` ggproto method has changed from doing nothing to transforming the data according to the scale(s) of the panel it has been assigned.

3. The `train_scales` ggproto method first transforms the data before training the scales.

Also, I've added a test for these transformations, but must note that I haven't tested all possible behaviour.

It should be no big problem to handle scale transformations in a potential future `facet_wrap_sc` in a similar way.