### PR TITLE
Adress date axis bug #13

### DIFF
--- a/R/facet_grid_sc.R
+++ b/R/facet_grid_sc.R
@@ -156,13 +156,31 @@ FacetGridScales <- ggproto(
       y_vars <- intersect(y_scales[[yidx]]$aesthetics, names(dat))
       x_vars <- intersect(x_scales[[xidx]]$aesthetics, names(dat))
 
-      # Transform variables by appropriate scale
-      for (j in y_vars) {
-        dat[, j] <- y_scales[[yidx]]$transform(dat[, j])
+      # Get scales
+      y_scale <- y_scales[[yidx]]
+      x_scale <- x_scales[[xidx]]
+
+      # It doesn't make sense to perform transforms on discrete scales
+      if (!x_scale$is_discrete()) {
+        # Get inverse transforms for class checking
+        x_inv <- x_scale$trans$inverse(1)
+        for (j in x_vars) {
+          if (inherits(dat[[j]], class(x_inv))) {
+            # Transform variables by appropriate scale
+            dat[, j] <- x_scale$transform(dat[, j])
+          }
+        }
       }
-      for (j in x_vars) {
-        dat[, j] <- x_scales[[xidx]]$transform(dat[, j])
+
+      if (!y_scale$is_discrete()) {
+        y_inv <- y_scale$trans$inverse(1)
+        for (j in y_vars) {
+          if (inherits(dat[[j]], class(y_inv))) {
+            dat[, j] <- y_scale$transform(dat[, j])
+          }
+        }
       }
+
       dat
     })
 

--- a/R/facet_grid_sc.R
+++ b/R/facet_grid_sc.R
@@ -161,7 +161,7 @@ FacetGridScales <- ggproto(
       x_scale <- x_scales[[xidx]]
 
       # It doesn't make sense to perform transforms on discrete scales
-      if (!x_scale$is_discrete()) {
+      if (!is.null(x_scale) && !x_scale$is_discrete()) {
         # Get inverse transforms for class checking
         x_inv <- x_scale$trans$inverse(1)
         for (j in x_vars) {
@@ -172,7 +172,7 @@ FacetGridScales <- ggproto(
         }
       }
 
-      if (!y_scale$is_discrete()) {
+      if (!is.null(y_scale) && !y_scale$is_discrete()) {
         y_inv <- y_scale$trans$inverse(1)
         for (j in y_vars) {
           if (inherits(dat[[j]], class(y_inv))) {

--- a/tests/testthat/test-facet_grid_sc.R
+++ b/tests/testthat/test-facet_grid_sc.R
@@ -31,3 +31,15 @@ test_that("facet_grid_sc() accepts transformations", {
   expect_identical(ctrl[ctrl$PANEL == 3, "y"],
                    test[test$PANEL == 3, "y"])
 })
+
+test_that("facet_grid_sc() accepts date scales", {
+  g <- ggplot() +
+    geom_point(aes(x = Sys.Date() - 10, y = 1),
+              data = data.frame(facet = "left")) +
+    geom_point(aes(x = Sys.Date() + 10, y = 1),
+               data = data.frame(facet = "right")) +
+    facet_grid_sc(vars(facet),
+                  scales = list(y = list(left = scale_y_log10(),
+                                         right = scale_y_sqrt())))
+  expect_silent(ggplotGrob(g))
+})


### PR DESCRIPTION
Should now not attempt transformation on any continuous scale that switches class upon transformation. Unless someone makes a `scale_(x/y)_log10date()` scale or anything, I think this is generally a safe choice and at least would let date scales be usable. Also disabled transformation for discrete scales because their transform method is just passing data along and don't have an inverse transform.